### PR TITLE
feat: implement SQLAlchemy events for automatic state management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Application Settings
 APP_NAME="Process Visualization API"
-APP_VERSION="2.1.0"  # Note: Version is managed in pyproject.toml, update using scripts/update-version.ps1
+APP_VERSION="2.2.0"  # Note: Version is managed in pyproject.toml, update using scripts/update-version.ps1
 DEBUG=false
 
 # API Settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 
 # Add metadata labels
 LABEL maintainer="AAK-MBU" \
-      version="2.1.0" \
+      version="2.2.0" \
       description="Process Dashboard API"
 
 # Use exec form for proper signal handling

--- a/app/api/v1/endpoints/processes.py
+++ b/app/api/v1/endpoints/processes.py
@@ -13,7 +13,7 @@ from app.db.database import SessionDep
 from app.models import Process, ProcessCreate, ProcessPublic, RetentionUpdate
 from app.services import ProcessService
 
-router = APIRouter(tags=["processes"])
+router = APIRouter()
 
 
 @router.post(
@@ -136,12 +136,9 @@ def get_process_searchable_fields(*, session: SessionDep, process_id: int) -> di
         },
     }
 
-    # Get metadata schema from process definition
     metadata_schema = process.meta.get("run_metadata_schema", {})
 
-    # Get actual metadata fields from data - use schema as fallback
     try:
-        # Simple approach: use the schema fields for now
         actual_metadata_fields = list(metadata_schema.keys())
     except Exception:
         actual_metadata_fields = []

--- a/app/api/v1/endpoints/runs.py
+++ b/app/api/v1/endpoints/runs.py
@@ -69,7 +69,6 @@ def list_process_runs(
     params: Params = Depends(),
 ) -> Page[ProcessRun]:
     """List all process runs with optional filters and sorting."""
-    # Build filtered statement using service layer
     try:
         statement = run_service.build_filtered_statement(
             process_id=process_id,
@@ -87,7 +86,6 @@ def list_process_runs(
             include_neutralized=True,
         )
     except ValueError as e:
-        # Convert service layer validation errors to HTTP errors
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     # Paginate and add Link headers

--- a/app/api/v1/endpoints/step_runs.py
+++ b/app/api/v1/endpoints/step_runs.py
@@ -67,13 +67,6 @@ def update_step_run(
     session.commit()
     session.refresh(step_run)
 
-    # Update parent run status
-    run = session.get(ProcessRun, step_run.run_id)
-    if run:
-        run.update_status()
-        session.add(run)
-        session.commit()
-
     return step_run
 
 
@@ -118,13 +111,6 @@ def rerun_step(*, session: SessionDep, step_run_id: int) -> ProcessStepRun:
     session.add(step_run)
     session.commit()
     session.refresh(step_run)
-
-    # Update parent run status
-    run = session.get(ProcessRun, step_run.run_id)
-    if run:
-        run.update_status()
-        session.add(run)
-        session.commit()
 
     return step_run
 

--- a/app/main.py
+++ b/app/main.py
@@ -17,12 +17,14 @@ from app.core.exceptions import (
     StepRunError,
 )
 from app.db.database import create_db_and_tables
+from app.models.events import register_events
 
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     """Application lifespan"""
     create_db_and_tables()
+    register_events()
     yield
 
 

--- a/app/models/events.py
+++ b/app/models/events.py
@@ -1,0 +1,81 @@
+"""SQLAlchemy event handlers for automatic model updates."""
+
+import logging
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def register_events():
+    """Register all SQLAlchemy event handlers."""
+    from app.models.process_run import ProcessRun
+    from app.models.process_step_run import ProcessStepRun
+
+    @event.listens_for(ProcessStepRun, "before_insert")
+    def set_step_index_on_insert(mapper, connection, target: ProcessStepRun):
+        """
+        Automatically populate step_index from related ProcessStep.
+
+        This event fires before inserting a new ProcessStepRun and sets
+        the step_index field based on the index of the related
+        ProcessStep.
+        """
+        # Only set if not explicitly provided (None or 0)
+        if target.step_index is None or target.step_index == 0:
+            session = Session.object_session(target)
+            if session and target.step_id:
+                # Use query to avoid identity map issues
+                from app.models.process_step import ProcessStep
+
+                step = session.query(ProcessStep).filter(ProcessStep.id == target.step_id).first()
+                if step:
+                    target.step_index = step.index
+                    logger.debug(
+                        "Event: Auto-set step_index=%s for step_run (step_id=%s)",
+                        step.index,
+                        target.step_id,
+                    )
+                else:
+                    # Default to 0 if step not found
+                    target.step_index = 0
+                    logger.warning(
+                        "Event: Step %s not found, defaulting step_index to 0",
+                        target.step_id,
+                    )
+
+    @event.listens_for(Session, "before_commit", propagate=True)
+    def update_run_status_before_commit(session):
+        """
+        Update parent ProcessRun status before commit.
+
+        This runs after flush but before commit,
+        allowing status changes to be included.
+        """
+        # Track which runs need updating
+        runs_to_update = set()
+
+        # Check all ProcessStepRun objects that were modified
+        for obj in session.identity_map.values():
+            if isinstance(obj, ProcessStepRun) and obj.run_id:
+                runs_to_update.add(obj.run_id)
+
+        # Update each affected run
+        for run_id in runs_to_update:
+            run = session.get(ProcessRun, run_id)
+            if run:
+                old_status = run.status
+                run.update_status()
+                new_status = run.status
+
+                if old_status != new_status:
+                    logger.debug(
+                        "Event: Updated run %s status from %s to %s before commit",
+                        run_id,
+                        old_status,
+                        new_status,
+                    )
+
+    logger.info("SQLAlchemy events registered successfully")
+    return True

--- a/app/models/process_step_run.py
+++ b/app/models/process_step_run.py
@@ -23,7 +23,7 @@ class ProcessStepRunBase(SQLModel):
     failure: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON))
     run_id: int | None = Field(default=None, foreign_key="process_run.id")
     step_id: int | None = Field(default=None, foreign_key="process_step.id")
-    step_index: int = Field(ge=0)
+    step_index: int | None = Field(default=None, ge=0)
 
     can_rerun: bool = Field(
         default=False, description="Whether this specific step run can be rerun"
@@ -55,7 +55,7 @@ class ProcessStepRunCreate(SQLModel):
     """Schema for creating a process step run."""
 
     step_id: int
-    step_index: int = Field(ge=0)
+    step_index: int | None = Field(default=None, ge=0)
     run_id: int
 
 

--- a/app/services/run_service.py
+++ b/app/services/run_service.py
@@ -75,7 +75,6 @@ class ProcessRunService:
         return ProcessStepRun(
             run_id=run_id,
             step_id=step.id,
-            step_index=step.index,
             can_rerun=step.is_rerunnable,
             rerun_config=rerun_config,
             max_reruns=max_reruns,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Process_Dashboard_API"
-version = "2.1.0"
+version = "2.2.0"
 description = "API for process visualization"
 authors = [
     {name = "MBU", email = "rpa@mbu.aarhus.dk"}

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "process-dashboard-api"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Resolves #27 

- Auto-populate step_index from ProcessStep.index on insert
- Auto-update ProcessRun.status when step statuses change
- Remove manual status update calls from service layer
- Make step_index optional in ProcessStepRunCreate schema